### PR TITLE
feat(tree): show full user text, click-to-locate, live refresh, persistent panel

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -4,7 +4,7 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAppSelector, useAppDispatch } from '../store'
 import {
-  switchSlot, createSlot, deleteSlot, fetchHistory,
+  switchSlot, createSlot, deleteSlot, fetchHistory, resumeFromHistory,
   loadOlderMessages, appendMessage,
   setSlotRunning, setSlotStopping, setPendingInput, clearResendQueued, promoteQueued,
 } from '../store/chatSlice'
@@ -65,6 +65,7 @@ export default function ChatPage() {
   const unreadSlots = useAppSelector(s => s.dashboard.unreadSlots)
   const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
   const activeSlot = useAppSelector(s => s.chat.activeSlot)
+  const history = useAppSelector(s => s.chat.history)
   const messages = useAppSelector(s => s.chat.messages)
   const slotRunning = useAppSelector(s => s.chat.slotRunning)
   const slotStopping = useAppSelector(s => s.chat.slotStopping)
@@ -100,7 +101,10 @@ export default function ChatPage() {
     window.addEventListener('storage', reload)
     return () => { window.removeEventListener('mc-chat-config', reload); window.removeEventListener('storage', reload) }
   }, [])
-  const [showTree, setShowTree] = useState(false)
+  // Persist tree-panel visibility so it survives remounts / page reloads
+  // (e.g. mobile browsers killing backgrounded tabs, server-update reloads).
+  const [showTree, setShowTree] = useState(() => localStorage.getItem('mc-chat-tree') === '1')
+  useEffect(() => { localStorage.setItem('mc-chat-tree', showTree ? '1' : '0') }, [showTree])
   const [showFiles, setShowFiles] = useState(false)
   const [showRefs, setShowRefs] = useState(false)
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
@@ -913,6 +917,60 @@ export default function ChatPage() {
   // Group consecutive tool messages for collapsible rendering
   const groupedMessages = useMemo(() => groupToolMessages(messages), [messages])
 
+  // Session-tree → chat locate: flash target on the grouped index, auto-clear.
+  const [treeHighlight, setTreeHighlight] = useState<number | null>(null)
+  useEffect(() => {
+    if (treeHighlight == null) return
+    const t = setTimeout(() => setTreeHighlight(null), 2400)
+    return () => clearTimeout(t)
+  }, [treeHighlight])
+
+  // Find the loaded message best matching a tree entry (exact text → prefix →
+  // nearest timestamp among same-role messages), scroll to it and flash it.
+  const handleTreeLocate = useCallback((entry: { role?: string; timestamp?: string; text?: string; fullText?: string }) => {
+    const roleMap: Record<string, string[]> = {
+      user: ['user', 'queued'],
+      assistant: ['assistant'],
+      toolResult: ['tool'],
+    }
+    const roles = roleMap[entry.role || ''] || [entry.role || '']
+    const want = entry.fullText || entry.text || ''
+    const entryTs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
+
+    let best = -1
+    let bestScore = Infinity
+    let nearest = -1
+    let nearestDt = Infinity
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i]
+      if (!roles.includes(m.role)) continue
+      if (!Number.isNaN(entryTs) && m.ts) {
+        const dt = Math.abs(Date.parse(m.ts) - entryTs)
+        if (dt < nearestDt) { nearestDt = dt; nearest = i }
+      }
+      if (!want) continue
+      const content = m.rawText || m.content
+      let score: number | null = null
+      if (content === want || m.content === want) score = 0
+      else if (entry.text && (content.startsWith(entry.text.slice(0, 120)) || m.content.startsWith(entry.text.slice(0, 120)))) score = 1
+      if (score == null) continue
+      // Timestamp proximity breaks ties between identical texts (< 1 so exact beats prefix)
+      if (!Number.isNaN(entryTs) && m.ts) score += Math.min(Math.abs(Date.parse(m.ts) - entryTs) / 60000, 0.5)
+      if (score < bestScore) { bestScore = score; best = i }
+    }
+    const msgIdx = best >= 0 ? best : nearest
+    if (msgIdx < 0) return
+    const gIdx = groupedMessages.findIndex(g =>
+      g.type === 'single' ? g.index === msgIdx : g.tools.some(t => t.index === msgIdx)
+    )
+    if (gIdx >= 0) {
+      virtuosoRef.current?.scrollToIndex({ index: gIdx, behavior: 'smooth', align: 'center' })
+      setTreeHighlight(gIdx)
+      // On mobile the tree is a full-screen overlay — close it so the located message is visible
+      if (window.innerWidth < 768) setShowTree(false)
+    }
+  }, [messages, groupedMessages])
+
   // Collect queued messages (with their absolute index) for the pills UI above the input
   const queuedMessages = useMemo(
     () => messages.map((m, idx) => ({ msg: m, idx })).filter(({ msg }) => msg.role === 'queued'),
@@ -1001,8 +1059,12 @@ export default function ChatPage() {
     <div className="flex flex-1 min-h-0 h-full">
       {!sidebarCollapsed && <ChatSidebar
         slots={slots}
+        history={history}
         activeSlot={activeSlot}
         unreadSlots={unreadSlots}
+        onResumeHistory={(session) => {
+          dispatch(resumeFromHistory({ key: session.key, title: session.title }))
+        }}
         onNewSessionInCwd={(cwd) => { setPendingCwd(cwd); wantsNewSession.current = true; dispatch(switchSlot(null)); setMobileSidebarOpen(false) }}
         onNewSession={() => { wantsNewSession.current = true; dispatch(switchSlot(null)); setMobileSidebarOpen(false) }}
         mobileOpen={mobileSidebarOpen}
@@ -1208,6 +1270,8 @@ export default function ChatPage() {
                     slotKey={activeSlot}
                     onFork={(newSlotKey, text) => { setShowTree(false); dispatch(switchSlot(newSlotKey)); if (text) { setInput(text); setTimeout(() => inputRef.current?.focus(), 100) } }}
                     onClose={() => setShowTree(false)}
+                    onLocate={handleTreeLocate}
+                    messageCount={messages.length}
                   />
                 </div>
               )}
@@ -1304,7 +1368,7 @@ export default function ChatPage() {
                 // Add turn separator before user messages (except the first)
                 const isUserTurn = item.type === 'single' && item.message.role === 'user' && _i > 0
                 return (
-                  <div className="px-5 py-2">
+                  <div className={`px-5 py-2 rounded-lg transition-colors duration-500 ${treeHighlight === _i ? 'bg-accent-subtle ring-2 ring-accent/50' : ''}`}>
                     {isUserTurn && <div className="border-t border-border/40 mb-4 mt-2" />}
                     {item.type === 'group' ? (
                       <ToolGroup tools={item.tools} renderTool={renderMessage} />
@@ -1497,4 +1561,3 @@ export default function ChatPage() {
     </div>
   )
 }
-

--- a/frontend/src/pages/chat/SessionTree.tsx
+++ b/frontend/src/pages/chat/SessionTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 
 interface TreeEntry {
   id: string
@@ -104,10 +104,12 @@ function TreeRow({ node, selected, onSelect, hasBranch }: {
 }) {
   const icon = ROLE_ICONS[node.role] || '·'
   const indent = Math.min(node.depth, 8) * 16
+  const displayText = node.fullText || node.text || node.type
 
   return (
     <button
       onClick={onSelect}
+      title={displayText}
       className={`w-full text-left flex items-start gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors border-none ${
         selected ? 'bg-accent-subtle border-accent/30' : 'bg-transparent hover:bg-bg-hover'
       }`}
@@ -116,10 +118,10 @@ function TreeRow({ node, selected, onSelect, hasBranch }: {
       {hasBranch && <span className="text-[10px] text-warning shrink-0 mt-0.5">⑂</span>}
       <span className="text-[12px] shrink-0">{icon}</span>
       <div className="flex-1 min-w-0">
-        <span className={`text-[12px] font-mono truncate block ${
+        <span className={`text-[12px] font-mono whitespace-pre-wrap break-words line-clamp-3 block ${
           node.isActive ? 'text-text' : 'text-muted'
         } ${node.isLeaf ? 'font-semibold text-accent' : ''}`}>
-          {node.text || node.type}
+          {displayText}
         </span>
         {node.tools && node.tools.length > 0 && (
           <span className="text-[10px] text-muted/60 truncate block">
@@ -132,10 +134,15 @@ function TreeRow({ node, selected, onSelect, hasBranch }: {
   )
 }
 
-export default function SessionTree({ slotKey, onFork, onClose }: {
+export default function SessionTree({ slotKey, onFork, onClose, onLocate, messageCount }: {
   slotKey: string
   onFork: (newSlotKey: string, text: string) => void
   onClose: () => void
+  /** Called when a row is clicked — lets the chat view scroll to the matching message. */
+  onLocate?: (entry: TreeEntry) => void
+  /** Live chat message count — bumps trigger a debounced tree refetch so new
+   *  user/assistant messages show up without reopening the panel. */
+  messageCount?: number
 }) {
   const [entries, setEntries] = useState<TreeEntry[]>([])
   const [leafId, setLeafId] = useState<string | null>(null)
@@ -144,14 +151,28 @@ export default function SessionTree({ slotKey, onFork, onClose }: {
   const [loading, setLoading] = useState(true)
   const [forking, setForking] = useState(false)
 
-  useEffect(() => {
-    setLoading(true)
-    fetch(`/api/chat/slots/${encodeURIComponent(slotKey)}/tree`)
+  const fetchTree = useCallback(() => {
+    return fetch(`/api/chat/slots/${encodeURIComponent(slotKey)}/tree`)
       .then(r => r.json())
       .then(d => { setEntries(d.entries || []); setLeafId(d.leafId || null) })
       .catch(() => {})
-      .finally(() => setLoading(false))
   }, [slotKey])
+
+  useEffect(() => {
+    setLoading(true)
+    fetchTree().finally(() => setLoading(false))
+  }, [fetchTree])
+
+  // Live refresh: new chat messages get appended to the session JSONL by pi,
+  // then show up here. Debounced; a delayed retry covers slow disk writes.
+  const skipFirstRefresh = useRef(true)
+  useEffect(() => {
+    if (messageCount == null) return
+    if (skipFirstRefresh.current) { skipFirstRefresh.current = false; return }
+    const t1 = setTimeout(fetchTree, 600)
+    const t2 = setTimeout(fetchTree, 2000)
+    return () => { clearTimeout(t1); clearTimeout(t2) }
+  }, [messageCount, fetchTree])
 
   const tree = useMemo(() => buildTree(entries, leafId), [entries, leafId])
   const visible = useMemo(() => flattenVisible(tree, filter), [tree, filter])
@@ -212,7 +233,7 @@ export default function SessionTree({ slotKey, onFork, onClose }: {
               key={node.id}
               node={node}
               selected={selected === node.id}
-              onSelect={() => setSelected(node.id)}
+              onSelect={() => { setSelected(node.id); onLocate?.(node) }}
               hasBranch={isBranchPoint(node, tree)}
             />
           ))
@@ -223,8 +244,8 @@ export default function SessionTree({ slotKey, onFork, onClose }: {
       <div className="flex items-center gap-2 px-3 py-2 border-t border-border shrink-0">
         {selected && selectedEntry ? (
           <>
-            <span className="text-[12px] text-muted truncate flex-1">
-              {ROLE_ICONS[selectedEntry.role] || '·'} {selectedEntry.text?.slice(0, 80) || selectedEntry.type}
+            <span className="text-[12px] text-muted truncate flex-1" title={selectedEntry.fullText || selectedEntry.text || selectedEntry.type}>
+              {ROLE_ICONS[selectedEntry.role] || '·'} {(selectedEntry.fullText || selectedEntry.text)?.slice(0, 200) || selectedEntry.type}
             </span>
             {canFork && (
               <button


### PR DESCRIPTION
## 问题 / Problems

Session Tree 面板有四个体验问题：

1. **消息只显示一句话** — 树节点用 `text`（截断 200 字符）+ CSS `truncate` 单行省略，用户消息里多行/多个问题只看得见第一句
2. **点击无法定位** — 点树节点只是选中（用于 fork），右侧聊天区不会滚动到对应消息
3. **不及时** — 树只在打开面板时拉取一次数据，之后发送的消息不会出现在树里
4. **面板状态丢失** — 切换窗口/页面重载后面板自动关闭，需要重新手动打开

## 修改 / Changes

- **显示完整消息**：树节点改用 `fullText`（后端本就有返回），样式从 `truncate` 改为 `line-clamp-3` + 换行保留，悬停 tooltip 显示全文
- **点击定位**：新增 `onLocate` 回调，ChatPage 按 精确文本 → 前缀 → 同角色时间戳最近 的策略匹配消息（重复文本用时间戳打分区分），`virtuosoRef.scrollToIndex` 平滑滚动居中 + 2.4s 高亮闪烁；移动端定位后自动关闭全屏树
- **实时刷新**：ChatPage 传入 `messageCount`，变化时防抖 600ms 重新拉取 tree（+ 2s 兜底重试覆盖 pi 写 JSONL 的延迟），新消息即刻出现在树中
- **状态持久化**：面板开关状态写入 `localStorage`（`mc-chat-tree`，与 `mc-chat-sidebar` 同模式），页面重载/组件重挂载后保持打开

## 影响面 / Scope

仅前端 2 个文件（`ChatPage.tsx`、`SessionTree.tsx`），无后端改动，无破坏性变更。`tsc -b` + 相关测试通过。